### PR TITLE
CI: add stale PR and issue config

### DIFF
--- a/.github/workflows/stale-issue.yml
+++ b/.github/workflows/stale-issue.yml
@@ -1,0 +1,29 @@
+name: Close inactive issues and prs
+on:
+  schedule:
+    - cron: "30 1 * * *"
+  workflow_dispatch:
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # Issues
+          days-before-issue-stale: 90
+          days-before-issue-close: 60
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 90 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 60 days since being marked as stale."
+          exempt-issue-labels: "enhancement"
+          # PR
+          days-before-pr-stale: 90
+          days-before-pr-close: 60
+          stale-pr-label: "stale"
+          stale-pr-message: "This PR is stale because it has been open for 90 days with no activity."
+          close-pr-message: "This PR was closed because it has been inactive for 60 days since being marked as stale."
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Description**:
Adds CI workflow to mark PRs and Issues:
* stale after 90 days
* and closed 60 days after becoming stale.

**Related issue(s)**:

Fixes #15 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
